### PR TITLE
Fixed syntax errors in fr.lang.php (#134)

### DIFF
--- a/core/lang/fr.lang.php
+++ b/core/lang/fr.lang.php
@@ -21,9 +21,9 @@
 $trans = array(
 
 /* Define some core language stuff */
-'invalid.php.version'	=> 'Vous n'utilisez pas PHP version 5.0 +',
+'invalid.php.version'	=> 'Vous n\'utilisez pas PHP version 5.0 +',
 'database.connection.failed'	=> 'La connexion à la base de données à échouée',
-'error'	=> 'Une erreur s'est produite (%s)', /* %s est la chaîne d\'erreur */
+'error'	=> 'Une erreur s\'est produite (%s)', /* %s est la chaîne d\'erreur */
 
 /*
 * Module language replacements


### PR DESCRIPTION
Added a backslash before two instances of single-quotation marks ( ' ), one in each of lines 24 and 26. They are supposed to be part of the localised string, but compiler would interpret it as string opener/closer.